### PR TITLE
Address 'interface conversion: string is not error: missing method Er…

### DIFF
--- a/stomp/client.go
+++ b/stomp/client.go
@@ -177,7 +177,12 @@ func (c *Client) listen() {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Warningf("stomp client: recover panic: %s", r)
-			c.done <- r.(error)
+			err, ok := r.(error)
+			if !ok {
+				c.done <- fmt.Errorf("%v", r)
+			} else {
+				c.done <- err
+			}
 		}
 	}()
 


### PR DESCRIPTION
Attempt to address `interface conversion: string is not error: missing method Error `

```
Jan 27 17:45:27 drone drone[9888]: 1:M 27 Jan 17:45:27.090 # stomp client: recover panic: send on closed channel
Jan 27 17:45:27 drone drone[9888]: panic: send on closed channel [recovered]
Jan 27 17:45:27 drone drone[9888]: #011panic: interface conversion: string is not error: missing method Error
Jan 27 17:45:27 drone drone[9888]: 
Jan 27 17:45:27 drone drone[9888]: goroutine 14 [running]:
Jan 27 17:45:27 drone drone[9888]: panic(0xd8ab80, 0xc82d0779c0)
Jan 27 17:45:27 drone drone[9888]: #011/usr/local/go/src/runtime/panic.go:481 +0x3e6
Jan 27 17:45:27 drone drone[9888]: stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).listen.func1(0xc820204720)
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:180 +0x103
Jan 27 17:45:27 drone drone[9888]: panic(0xc39440, 0xc823b39cd0)
Jan 27 17:45:27 drone drone[9888]: #011/usr/local/go/src/runtime/panic.go:443 +0x4e9
Jan 27 17:45:27 drone drone[9888]: stuff.test.com/drone/drone-release/vendor/github.com/drone/drone/server.LogStream.func1(0xc82670d040)
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/drone/server/stream.go:76 +0xce
Jan 27 17:45:27 drone drone[9888]: stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp.HandlerFunc.Handle(0xc82792a620, 0xc82670d040)
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp/handler.go:13 +0x26
Jan 27 17:45:27 drone drone[9888]: stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).handleMessage(0xc820204720, 0xc82670d040)
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:227 +0x25e
Jan 27 17:45:27 drone drone[9888]: stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).listen(0xc820204720)
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:193 +0x16c
Jan 27 17:45:27 drone drone[9888]: created by stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).Connect
Jan 27 17:45:27 drone drone[9888]: #011/go/src/stuff.test.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:151 +0x2ae
```