### PR TITLE
Print stacktrace when recovering from panic

### DIFF
--- a/stomp/client.go
+++ b/stomp/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -179,8 +180,10 @@ func (c *Client) listen() {
 			logger.Warningf("stomp client: recover panic: %s", r)
 			err, ok := r.(error)
 			if !ok {
+				logger.Warningf("%v: %s", r, debug.Stack())
 				c.done <- fmt.Errorf("%v", r)
 			} else {
+				logger.Warningf("%s", err)
 				c.done <- err
 			}
 		}


### PR DESCRIPTION
Been running into the following errors:

```
Feb  3 17:13:39 drone5-server drone5[9888]: time="2017-02-03T17:13:39Z" level=in
fo ip=x.x.x.x latency=1m30.248471505s method=GET path="/ws/logs/repo/name/402/1" status=200 time="2017-02-03T17:13:39Z" user-agent="Mozilla/5.0 (Ma
cintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/5
5.0.2883.95 Safari/537.36"
Feb  3 17:13:39 drone5-server drone5[9888]: 1:M 03 Feb 17:13:39.638 # stomp client: recover panic: send on closed channel
Feb  3 17:13:41 drone5-server drone5[9888]: time="2017-02-03T17:13:41Z" level=info ip=x.x.x.x latency=3.417983ms method=GET path="/api/builds" status=200 time="2017-02-03T17:13:41Z" user-agent="Go-http-client/1.1"
```

No stack trace is printed.  This PR adds printing the stack trace to help with debugging issues from panic recovery.  The above then becomes something like:

```
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: 1:M 07 Feb 05:05:05.003 # stomp client: recover panic: send on closed channel
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: 1:M 07 Feb 05:05:05.003 # send on closed channel: goroutine 20 [running]:
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: runtime/debug.Stack(0x0, 0x0, 0x0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/usr/local/go/src/runtime/debug/stack.go:24 +0x80
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).listen.func1(0xc8200584e0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:187 +0x14c
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: panic(0xc3a5a0, 0xc821030bb0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/usr/local/go/src/runtime/panic.go:443 +0x4e9
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: vcs.com/drone/drone-release/vendor/github.com/drone/drone/server.LogStream.func1(0xc820fc24e0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/drone/server/stream.go:109 +0x781
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp.HandlerFunc.Handle(0xc8205f15c0, 0xc820fc24e0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp/handler.go:13 +0x26
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).handleMessage(0xc8200584e0, 0xc820fc24e0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:239 +0x25e
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).listen(0xc8200584e0)
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:205 +0x16c
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: created by vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp.(*Client).Connect
Feb  7 05:05:05 drone-dev-2-server drone_dev[764]: #011/go/src/vcs.com/drone/drone-release/vendor/github.com/drone/mq/stomp/client.go:156 +0x2ae
```